### PR TITLE
64-bit linux (x86_64) support

### DIFF
--- a/myppy/__init__.py
+++ b/myppy/__init__.py
@@ -130,6 +130,8 @@ elif sys.platform == "win32":
 else:
     raise ImportError("myppy not available on platform %r" % (sys.platform,))
 
+from myppy import util
+
 
 
 def main(argv):
@@ -138,9 +140,20 @@ def main(argv):
         argv = argv + [".","help"]
     elif len(argv) < 3:
         argv = argv + ["help"]
-    target = MyppyEnv(argv[1])
     cmd = argv[2]
     args = argv[3:]
+
+    # Default architecture - 32bit on 32-bit linux and 64bit on 64-bit linux.
+    architecture = util.python_architecture()
+    # User is allowed to specify architecture of myppy python environment.
+    # If no architecture is specified - defaults to the architecture
+    # of Python (32bit on linux-i686 and 64bit on linux-x86_64)
+    if cmd == 'init' and len(args) == 1:
+        architecture = args[0]
+        args = []
+    # We need to pass 32bit or 64bit to MyppyEnv.
+    target = MyppyEnv(argv[1], architecture)
+
     if cmd == "help":
         print ""
         print "myppy: make you a portable python"
@@ -175,10 +188,7 @@ class _init(_cmd):
     """initialise a new portable python env"""
     @staticmethod
     def run(target,args):
-        # Allow the user to specify architecture '32bit' or '64bit' as part
-        # of environment setup. If not specified defaults to the architecture
-        # of host OS. (Linux only).
-        assert not args or len(args) == 1
+        assert not args
         target.init(args)
 
 class _clean(_cmd):

--- a/myppy/__init__.py
+++ b/myppy/__init__.py
@@ -175,8 +175,11 @@ class _init(_cmd):
     """initialise a new portable python env"""
     @staticmethod
     def run(target,args):
-        assert not args
-        target.init()
+        # Allow the user to specify architecture '32bit' or '64bit' as part
+        # of environment setup. If not specified defaults to the architecture
+        # of host OS. (Linux only).
+        assert not args or len(args) == 1
+        target.init(args)
 
 class _clean(_cmd):
     """clean out temporary files (e.g. build files)"""

--- a/myppy/envs/base.py
+++ b/myppy/envs/base.py
@@ -113,7 +113,7 @@ class MyppyEnv(object):
     def SITE_PACKAGES(self):
         return os.path.join(self.PREFIX,"lib","python2.7","site-packages")
 
-    def init(self, args):
+    def init(self, args=[]):
         """Build the base myppy python environment."""
         # User is allowed to specify architecture of myppy python environment.
         # If no architecture is specified - defaults to the architecture

--- a/myppy/envs/base.py
+++ b/myppy/envs/base.py
@@ -52,7 +52,7 @@ class MyppyEnv(object):
 
     DB_NAME = os.path.join("local","myppy.db")
 
-    def __init__(self,rootdir):
+    def __init__(self,rootdir, architecture):
         if not isinstance(rootdir,unicode):
             rootdir = rootdir.decode(sys.getfilesystemencoding())
         self.rootdir = os.path.abspath(rootdir)
@@ -69,9 +69,9 @@ class MyppyEnv(object):
             os.makedirs(os.path.dirname(dbpath))
         self._db = sqlite3.connect(dbpath,isolation_level=None)
         self._initdb()
-        # Whether to build 32bit or 64bit architecture. Defaults to archtecture
+        # Whether to build 32bit or 64bit architecture. Defaults to architecture
         # of Python interpreter.
-        self.ARCH = util.python_architecture()
+        self.ARCH = architecture
 
     def __enter__(self):
         if not self._has_db_lock:
@@ -124,11 +124,6 @@ class MyppyEnv(object):
 
     def init(self, args=[]):
         """Build the base myppy python environment."""
-        # User is allowed to specify architecture of myppy python environment.
-        # If no architecture is specified - defaults to the architecture
-        # of Python (32bit on linux-i686 and 64bit on linux-x86_64)
-        if len(args) == 1:
-            self.ARCH = args[0]
         for dep in self.DEPENDENCIES:
             self.install(dep,initialising=True,explicit=False)
         

--- a/myppy/envs/base.py
+++ b/myppy/envs/base.py
@@ -60,6 +60,9 @@ class MyppyEnv(object):
             os.makedirs(os.path.dirname(dbpath))
         self._db = sqlite3.connect(dbpath,isolation_level=None)
         self._initdb()
+        # Whether to build 32bit or 64bit architecture. Defaults to archtecture
+        # of Python interpreter.
+        self.arch = util.python_architecture()
 
     def __enter__(self):
         if not self._has_db_lock:
@@ -110,8 +113,13 @@ class MyppyEnv(object):
     def SITE_PACKAGES(self):
         return os.path.join(self.PREFIX,"lib","python2.7","site-packages")
 
-    def init(self):
+    def init(self, args):
         """Build the base myppy python environment."""
+        # User is allowed to specify architecture of myppy python environment.
+        # If no architecture is specified - defaults to the architecture
+        # of Python (32bit on linux-i686 and 64bit on linux-x86_64)
+        if len(args) == 1:
+            self.arch = args[0]
         for dep in self.DEPENDENCIES:
             self.install(dep,initialising=True,explicit=False)
         

--- a/myppy/envs/base.py
+++ b/myppy/envs/base.py
@@ -62,7 +62,7 @@ class MyppyEnv(object):
         self._initdb()
         # Whether to build 32bit or 64bit architecture. Defaults to archtecture
         # of Python interpreter.
-        self.arch = util.python_architecture()
+        self.ARCH = util.python_architecture()
 
     def __enter__(self):
         if not self._has_db_lock:
@@ -119,7 +119,7 @@ class MyppyEnv(object):
         # If no architecture is specified - defaults to the architecture
         # of Python (32bit on linux-i686 and 64bit on linux-x86_64)
         if len(args) == 1:
-            self.arch = args[0]
+            self.ARCH = args[0]
         for dep in self.DEPENDENCIES:
             self.install(dep,initialising=True,explicit=False)
         

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -18,30 +18,36 @@ class MyppyEnv(base.MyppyEnv):
     DEPENDENCIES.extend(base.MyppyEnv.DEPENDENCIES)
 
     @property
+    def _arch_switch(self):
+        """Return cli option for the compiler to compile 32bit or 64bit app."""
+        switch = {'32bit': '-m32', '64bit': '-m64'}
+        retutn switch[self.ARCH]
+
+    @property
     def CC(self):
-        return "lsbcc -m32"
+        return "lsbcc " + self._arch_switch
 
     @property
     def CXX(self):
-        return "lsbc++ -m32"
+        return "lsbc++ " + self._arch_switch
 
     @property
     def LDFLAGS(self):
-        flags = "-m32"
+        flags = self._arch_switch + ''
         for libdir in ("lib", "opt/lsb/lib"):
             flags += " -L" + os.path.join(self.PREFIX,libdir)
         return flags
 
     @property
     def CFLAGS(self):
-        flags = "-Os -D_GNU_SOURCE -DNDEBUG -m32"
+        flags = "-Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
         for incdir in ("include", "opt/lsb/include"):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def CXXFLAGS(self):
-        flags = "-Os -D_GNU_SOURCE -DNDEBUG -m32"
+        flags = "-Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
         for incdir in ("include", "opt/lsb/include"):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -44,14 +44,14 @@ class MyppyEnv(base.MyppyEnv):
 
     @property
     def CFLAGS(self):
-        flags = "-Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
+        flags = "-fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
         for incdir in ("include", "opt/lsb/include"):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def CXXFLAGS(self):
-        flags = "-Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
+        flags = "-fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
         for incdir in ("include", "opt/lsb/include"):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -34,7 +34,11 @@ class MyppyEnv(base.MyppyEnv):
     @property
     def LDFLAGS(self):
         flags = self._arch_switch + ''
-        for libdir in ("lib", "opt/lsb/lib"):
+        dirs = {
+                '32bit':("lib", "opt/lsb/lib"),
+                '64bit':('lib', 'opt/lsb/lib64'),
+        }
+        for libdir in dirs[self.ARCH]:
             flags += " -L" + os.path.join(self.PREFIX,libdir)
         return flags
 

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -42,28 +42,26 @@ class MyppyEnv(base.MyppyEnv):
         #  to choose the dynamic linker at runtime. This trades
         #  lsb-compatability for ability to run out-of-the-box on more linuxen.
         flags = self._arch_switch + ' --lsb-besteffort ' + ' '
-        for libdir in ("lib", ):
-            flags += " -L" + os.path.join(self.PREFIX,libdir)
         return flags
 
     @property
     def CFLAGS(self):
-        flags = " --lsb-besteffort -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch + ' '
+        flags = " -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch + ' '
+        # Some recipes might not be able to find ncurses. Include it explicitly.
         for incdir in ("include", 'include/ncurses'):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def CXXFLAGS(self):
-        flags = " --lsb-besteffort -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
+        flags = " -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
         for incdir in ("include", ):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def LD_LIBRARY_PATH(self):
-        #return os.path.join(self.PREFIX,"lib")
-        return ''
+        return os.path.join(self.PREFIX,"lib")
 
     @property
     def PKG_CONFIG_PATH(self):
@@ -94,7 +92,9 @@ class MyppyEnv(base.MyppyEnv):
         # Where to look for additional libraries outside LSB specification.
         self.env["LSB_SHAREDLIBPATH"] = os.path.join(self.PREFIX,"lib")
         # Shared libraries outside LSB spec to be allowed to link with.
-        self.env["LSBCC_SHAREDLIBS"] = "bz2:crypto:ncurses:ncursesw:python:python2.7:readline"
+        # Not having 'python' causes to link 'libpython' statically with every
+        # Python C extension and drastically increases size of myppy environment.
+        self.env["LSBCC_SHAREDLIBS"] = "bz2:crypto:ncurses:ncursesw:python:python2.7:readline:ssl"
         # For debugging lsbcc options.
         #self.env["LSBCC_VERBOSE"] = '0x0040'
 

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -68,8 +68,8 @@ class MyppyEnv(base.MyppyEnv):
         return ":".join((os.path.join(self.PREFIX,"lib/pkgconfig"),
                          os.path.join(self.PREFIX, self._lsb_libdir, 'pkgconfig'),))
 
-    def __init__(self,rootdir):
-        super(MyppyEnv,self).__init__(rootdir)
+    def __init__(self,rootdir, architecture):
+        super(MyppyEnv,self).__init__(rootdir, architecture)
         if not os.path.exists(os.path.join(self.PREFIX,"lib")):
             os.makedirs(os.path.join(self.PREFIX,"lib"))
         self.env["CC"] = self.CC

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -41,28 +41,29 @@ class MyppyEnv(base.MyppyEnv):
         #  the special lsb-specified loader but uses best-effort code
         #  to choose the dynamic linker at runtime. This trades
         #  lsb-compatability for ability to run out-of-the-box on more linuxen.
-        flags = self._arch_switch + ' --lsb-besteffort '
-        for libdir in ("lib", self._lsb_libdir):
+        flags = self._arch_switch + ' --lsb-besteffort ' + ' '
+        for libdir in ("lib", ):  #self._lsb_libdir):
             flags += " -L" + os.path.join(self.PREFIX,libdir)
         return flags
 
     @property
     def CFLAGS(self):
-        flags = " --lsb-besteffort -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
-        for incdir in ("include", "opt/lsb/include"):
+        flags = " --lsb-besteffort -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch + ' '
+        for incdir in ("include", 'include/ncurses'):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def CXXFLAGS(self):
         flags = " --lsb-besteffort -fPIC -Os -D_GNU_SOURCE -DNDEBUG " + self._arch_switch
-        for incdir in ("include", "opt/lsb/include"):
+        for incdir in ("include", ):
             flags += " -I" + os.path.join(self.PREFIX,incdir)
         return  flags
 
     @property
     def LD_LIBRARY_PATH(self):
-        return os.path.join(self.PREFIX,"lib")
+        #return os.path.join(self.PREFIX,"lib")
+        return ''
 
     @property
     def PKG_CONFIG_PATH(self):
@@ -79,14 +80,21 @@ class MyppyEnv(base.MyppyEnv):
         self.env["CFLAGS"] = self.CFLAGS
         self.env["CXXFLAGS"] = self.CXXFLAGS
         self._add_env_path("PATH",os.path.join(self.PREFIX,"opt/lsb/bin"),1)
-        self._add_env_path("PKG_CONFIG_PATH",self.PKG_CONFIG_PATH)
-        self.env["PKG_CONFIG_SYSROOT_DIR"] = self.PREFIX.rstrip("/")
+        #self._add_env_path("PKG_CONFIG_PATH",self.PKG_CONFIG_PATH)
+        #self.env["PKG_CONFIG_SYSROOT_DIR"] = self.PREFIX.rstrip("/")
+        #self.env['PKG_CONFIG_LIBDIR'] =
+        # Linux Standard Base (LSB) specific environment variables. (for commands lsbcc / lsbc++)
         self.env["LSBCC_LIBS"] = os.path.join(self.PREFIX, self._lsb_libdir)
+        #self.env["LSBCC_INCLUDES"] = os.path.join(self.PREFIX,"include")
         self.env["LSBCC_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
+        #self.env["LSBCXX_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
         self.env["LSBCXX_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
         self.env["LSB_SHAREDLIBPATH"] = os.path.join(self.PREFIX,"lib")
-        self.env["LSBCC_SHAREDLIBS"] = "python:python2.7:crypto:readline:bz2"
-        self.env["LSBCC_VERBOSE"] = os.path.join(self.PREFIX,"lib")
+        #self.env["LSB_SHAREDLIBPATH"] = os.path.join(self.PREFIX,"lib") + ':' + os.path.join(self.PREFIX,"opt/lsb/lib64")
+        self.env["LSBCC_SHAREDLIBS"] = "bz2:crypto:ncurses:ncursesw:python:python2.7:readline"
+        #self.env["LSBCC_SHAREDLIBS"] = "ncurses"
+        #self.env["LSBCC_VERBOSE"] = os.path.join(self.PREFIX,"lib")
+        self.env["LSBCC_VERBOSE"] = '0x0040'
 
     def record_files(self,recipe,files):
         if recipe not in ("bin_lsbsdk",):

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -21,7 +21,7 @@ class MyppyEnv(base.MyppyEnv):
     def _arch_switch(self):
         """Return cli option for the compiler to compile 32bit or 64bit app."""
         switch = {'32bit': '-m32', '64bit': '-m64'}
-        retutn switch[self.ARCH]
+        return switch[self.ARCH]
 
     @property
     def CC(self):

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -42,6 +42,9 @@ class MyppyEnv(base.MyppyEnv):
         #  to choose the dynamic linker at runtime. This trades
         #  lsb-compatability for ability to run out-of-the-box on more linuxen.
         flags = self._arch_switch + ' --lsb-besteffort ' + ' '
+        # Some recipes require this -L/libdir ldflag.
+        for libdir in ('lib', ):
+            flags += ' -L' + os.path.join(self.PREFIX, libdir)
         return flags
 
     @property

--- a/myppy/envs/linux.py
+++ b/myppy/envs/linux.py
@@ -42,7 +42,7 @@ class MyppyEnv(base.MyppyEnv):
         #  to choose the dynamic linker at runtime. This trades
         #  lsb-compatability for ability to run out-of-the-box on more linuxen.
         flags = self._arch_switch + ' --lsb-besteffort ' + ' '
-        for libdir in ("lib", ):  #self._lsb_libdir):
+        for libdir in ("lib", ):
             flags += " -L" + os.path.join(self.PREFIX,libdir)
         return flags
 
@@ -80,21 +80,23 @@ class MyppyEnv(base.MyppyEnv):
         self.env["CFLAGS"] = self.CFLAGS
         self.env["CXXFLAGS"] = self.CXXFLAGS
         self._add_env_path("PATH",os.path.join(self.PREFIX,"opt/lsb/bin"),1)
-        #self._add_env_path("PKG_CONFIG_PATH",self.PKG_CONFIG_PATH)
-        #self.env["PKG_CONFIG_SYSROOT_DIR"] = self.PREFIX.rstrip("/")
-        #self.env['PKG_CONFIG_LIBDIR'] =
-        # Linux Standard Base (LSB) specific environment variables. (for commands lsbcc / lsbc++)
+        self._add_env_path("PKG_CONFIG_PATH",self.PKG_CONFIG_PATH)
+        self.env["PKG_CONFIG_SYSROOT_DIR"] = self.PREFIX.rstrip("/")
+        # PKG_CONFIG_LIBDIR tells pkg-config where to look for .pc files.
+        self.env['PKG_CONFIG_LIBDIR'] = os.path.join(self.PREFIX, 'lib') + ':' +  os.path.join(self.PREFIX, self._lsb_libdir) 
+
+        ## Linux Standard Base (LSB) specific environment variables. (for commands lsbcc / lsbc++)
+        # Path to LSB stub libraries.
         self.env["LSBCC_LIBS"] = os.path.join(self.PREFIX, self._lsb_libdir)
-        #self.env["LSBCC_INCLUDES"] = os.path.join(self.PREFIX,"include")
+        # Path to LSB C/C++ header files.
         self.env["LSBCC_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
-        #self.env["LSBCXX_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
         self.env["LSBCXX_INCLUDES"] = os.path.join(self.PREFIX,"opt/lsb/include")
+        # Where to look for additional libraries outside LSB specification.
         self.env["LSB_SHAREDLIBPATH"] = os.path.join(self.PREFIX,"lib")
-        #self.env["LSB_SHAREDLIBPATH"] = os.path.join(self.PREFIX,"lib") + ':' + os.path.join(self.PREFIX,"opt/lsb/lib64")
+        # Shared libraries outside LSB spec to be allowed to link with.
         self.env["LSBCC_SHAREDLIBS"] = "bz2:crypto:ncurses:ncursesw:python:python2.7:readline"
-        #self.env["LSBCC_SHAREDLIBS"] = "ncurses"
-        #self.env["LSBCC_VERBOSE"] = os.path.join(self.PREFIX,"lib")
-        self.env["LSBCC_VERBOSE"] = '0x0040'
+        # For debugging lsbcc options.
+        #self.env["LSBCC_VERBOSE"] = '0x0040'
 
     def record_files(self,recipe,files):
         if recipe not in ("bin_lsbsdk",):

--- a/myppy/envs/macosx.py
+++ b/myppy/envs/macosx.py
@@ -94,8 +94,8 @@ class MyppyEnv(base.MyppyEnv):
     def CXX(self):
         return self.DEPLOYMENT_TARGET_SETTINGS["CXX"]
 
-    def __init__(self,rootdir):
-        super(MyppyEnv,self).__init__(rootdir)
+    def __init__(self,rootdir, architecture):
+        super(MyppyEnv,self).__init__(rootdir, architecture)
         self.env["CC"] = "/usr/bin/gcc"
         self.env["CXX"] = "/usr/bin/g++"
         self.env["MACOSX_DEPLOYMENT_TARGET"] = self.MACOSX_DEPLOYMENT_TARGET

--- a/myppy/recipes/base.py
+++ b/myppy/recipes/base.py
@@ -492,7 +492,11 @@ class lib_openssl(Recipe):
 
 
 class lib_sqlite3(Recipe):
-    SOURCE_URL = "http://www.sqlite.org/sqlite-autoconf-3070500.tar.gz"
+    SOURCE_URL = "http://www.sqlite.org/sqlite-autoconf-3071201.tar.gz"
+    SOURCE_MD5 = 'eb7bbd258913518ad30971ea7ecb0ca9'
+    CONFIGURE_ARGS = ('--enable-static', '--enable-shared',
+        '--disable-readline', '--disable-dynamic-extensions',
+    )
 
 
 class py_setuptools(PyRecipe):

--- a/myppy/recipes/base.py
+++ b/myppy/recipes/base.py
@@ -150,6 +150,8 @@ class Recipe(object):
         if relpath is None:
             relpath = self.MAKE_RELPATH
         cmd = ["make"]
+        # Parallel execution of compilation.
+        cmd.append('-j3')
         if vars is not None:
             cmd.extend(vars)
         if makefile is not None:

--- a/myppy/recipes/base.py
+++ b/myppy/recipes/base.py
@@ -408,7 +408,7 @@ class lib_bz2(Recipe):
 
 
 class lib_readline(Recipe):
-    SOURCE_URL = "ftp://ftp.cwru.edu/pub/bash/readline-6.2.tar.gz"
+    SOURCE_URL = "ftp://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz"
     SOURCE_MD5 = "67948acb2ca081f23359d0256e9a271c"
     CONFIGURE_ARGS = ("--disable-shared","--enable-static",)
 

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -220,8 +220,8 @@ class lib_ncurses(Recipe):
     SOURCE_URL = 'http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz'
     SOURCE_MD5 = '8cb9c412e5f2d96bc6f459aa8c6282a1'
     CONFIGURE_ARGS = [
-        '--with-shared',
-        '--with-static',
+        #'--with-shared',
+        #'--with-static',
         '--enable-widec'
         '--with-mmask-t=long', '--disable-ext-colors',
         '--without-pthread',

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -352,7 +352,13 @@ class lib_wxwidgets_base(base.lib_wxwidgets_base,Recipe):
 
 
 class bin_lsbsdk(Recipe):
-    SOURCE_URL = "http://ftp.linuxfoundation.org/pub/lsb/bundles/released-4.1.0/sdk/lsb-sdk-4.1.5-1.ia32.tar.gz"
+    @property
+    def SOURCE_URL(self):
+        url = {
+                '32bit': 'http://ftp.linuxfoundation.org/pub/lsb/bundles/released-4.1.0/sdk/lsb-sdk-4.1.5-1.ia32.tar.gz',
+                '64bit': 'http://ftp.linuxfoundation.org/pub/lsb/bundles/released-4.1.0/sdk/lsb-sdk-4.1.5-1.x86_64.tar.gz',
+        }
+        return url[self.target.ARCH]
     def build(self):
         pass
     def install(self):

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -192,8 +192,8 @@ class python27(base.python27,Recipe,):
         self._patch_file(os.path.join(self.PREFIX, "lib/python2.7/distutils/util.py"),hardcode_platform)
 
 class patchelf(Recipe):
-    SOURCE_URL = "http://hydra.nixos.org/build/114505/download/2/patchelf-0.5.tar.bz2"
-    SOURCE_MD5 = "c41fc98091d15dc93ba876c3ef11f43c"
+    SOURCE_URL = "http://hydra.nixos.org/build/1524660/download/2/patchelf-0.6.tar.bz2"
+    SOURCE_MD5 = "5087261514b4b5814a39c3d3a36eb6ef"
 
 
 class lib_openssl(base.lib_openssl,Recipe):

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -201,8 +201,6 @@ class lib_openssl(base.lib_openssl,Recipe):
         super(lib_openssl,self)._configure()
         def ensure_gnu_source(lines):
             arch_switch = self.target._arch_switch  # -m32 or -m64
-            print 30 * 'S'
-            print arch_switch
             for ln in lines:
                 if ln.startswith("CFLAG="):
                     ln = ln.strip() + ' -D_GNU_SOURCE %s\n' % arch_switch

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -220,8 +220,7 @@ class lib_ncurses(Recipe):
     SOURCE_URL = 'http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz'
     SOURCE_MD5 = '8cb9c412e5f2d96bc6f459aa8c6282a1'
     CONFIGURE_ARGS = [
-        #'--with-shared',
-        #'--with-static',
+        '--with-shared',
         '--enable-widec'
         '--with-mmask-t=long', '--disable-ext-colors',
         '--without-pthread',

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -200,9 +200,12 @@ class lib_openssl(base.lib_openssl,Recipe):
     def _configure(self):
         super(lib_openssl,self)._configure()
         def ensure_gnu_source(lines):
+            arch_switch = self.target._arch_switch  # -m32 or -m64
+            print 30 * 'S'
+            print arch_switch
             for ln in lines:
                 if ln.startswith("CFLAG="):
-                    ln = ln.strip() + " -D_GNU_SOURCE -m32\n"
+                    ln = ln.strip() + ' -D_GNU_SOURCE %s\n' % arch_switch
                     ln = ln.replace("-O3","-Os")
                     yield ln
                 else:

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -185,11 +185,13 @@ class python27(base.python27,Recipe,):
         #  We can't do this until after the build has completed.
         super(python27, self).install()
         def hardcode_platform(lines):
+            architecture = {'32bit': 'linux-i686', '64bit': 'linux-x86_64'}
             for ln in lines:
                 yield ln
                 if ln.strip() == "def get_platform ():":
-                    yield "    return 'linux-i686'\n\n"
+                    yield "    return '%s'\n\n" % architecture[self.target.ARCH]
         self._patch_file(os.path.join(self.PREFIX, "lib/python2.7/distutils/util.py"),hardcode_platform)
+
 
 class patchelf(Recipe):
     SOURCE_URL = "http://hydra.nixos.org/build/1524660/download/2/patchelf-0.6.tar.bz2"

--- a/myppy/recipes/linux.py
+++ b/myppy/recipes/linux.py
@@ -146,7 +146,10 @@ class cmake(base.cmake,Recipe):
 
 class python27(base.python27,Recipe,):
     """Install the basic Python interpreter, with myppy support."""
-    DEPENDENCIES = ["lib_openssl"]
+    # Without ncurses the '_curses' python module is not compiled properly.
+    # LSB version of ncurses library does not contain some symbols that this
+    # '_curses' module needs.
+    DEPENDENCIES = ["lib_openssl", 'lib_ncurses']
 
     def _post_config_patch(self):
         super(python27,self)._post_config_patch()
@@ -211,6 +214,38 @@ class lib_openssl(base.lib_openssl,Recipe):
                 else:
                     yield ln
         self._patch_build_file("Makefile",ensure_gnu_source)
+
+
+class lib_ncurses(Recipe):
+    SOURCE_URL = 'http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz'
+    SOURCE_MD5 = '8cb9c412e5f2d96bc6f459aa8c6282a1'
+    CONFIGURE_ARGS = [
+        '--with-shared',
+        '--with-static',
+        '--enable-widec'
+        '--with-mmask-t=long', '--disable-ext-colors',
+        '--without-pthread',
+        '--without-reentrant',
+        '--without-hashed-db',
+        '--disable-termcap',
+        '--enable-symlinks',
+        # Disable C++ bindings otherwise fails to compile.
+        '--without-cxx', '--without-cxx-binding',
+        '--without-ada',
+        '--with-rcs-ids',
+        '--without-manpages',
+        '--without-progs',
+        '--without-tests',
+        '--enable-const',
+        '--enable-colorfgbg',
+        '--enable-echo',
+        # This forces ncures using terminfo from host OS.
+        '--with-default-terminfo-dir=/usr/share/terminfo',
+        # Without mouse.
+        '--disable-ext-mouse',
+        '--with-sysmouse',
+        '--without-gpm',
+    ]
 
 
 class py_cxfreeze(PyRecipe):

--- a/myppy/util.py
+++ b/myppy/util.py
@@ -171,3 +171,13 @@ def isrealdir(path):
     """Check if path is a real directory, not a symlink to a directory."""
     return (os.path.isdir(path) and not os.path.islink(path))
 
+
+def python_architecture():
+    """Check architecture (32/64 bit) of python interpreter."""
+    if sys.platform.startswith('darwin'):
+        if sys.maxint > 2L ** 32:
+            return '64bit'
+        else:
+            return '32bit'
+    else:
+        return platform.architecture()[0]

--- a/myppy/util.py
+++ b/myppy/util.py
@@ -16,6 +16,7 @@ import subprocess
 import shutil
 import hashlib
 import contextlib
+import platform
 from fnmatch import fnmatch
 
 

--- a/scripts/test_python.py
+++ b/scripts/test_python.py
@@ -1,0 +1,10 @@
+# The following modules contain some binary C extensions that might cause
+# import errors if not properly compiled.
+
+# If you do not see any ImportError exceptions then they should work as expected.
+
+import curses
+import hashlib
+import readline
+import sqlite3
+import ssl

--- a/scripts/test_python_curses.py
+++ b/scripts/test_python_curses.py
@@ -1,0 +1,10 @@
+import curses
+
+myscreen = curses.initscr()
+
+myscreen.border(0)
+myscreen.addstr(12, 25, "Python curses in action!")
+myscreen.refresh()
+myscreen.getch()
+
+curses.endwin()


### PR DESCRIPTION
These changes add support for compiling myppy as 64bit on linux.

It is now possible on 64bit linux to specify if myppy should be compiled as 32 or 64bit. To do that, the user can tell the architecture explicitly
# > myppy PATH/TO/ENV init  [ 32bit | 64bit ]

By default myppy will compile on 32bit linux as 32bit on 64bit linux as 64bit.
